### PR TITLE
Fix type checking for python < 3.9

### DIFF
--- a/mypy_gitlab_code_quality/__init__.py
+++ b/mypy_gitlab_code_quality/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 import re
 from base64 import b64encode

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,7 +7,7 @@ description = Simple script to generate gitlab code quality report from output o
 long_description = file: README.md
 long_description_content_type = text/markdown
 url = https://github.com/soul-catcher/mypy-gitlab-code-quality
-version = 0.0.11
+version = 0.0.12
 classifiers =
     Development Status :: 3 - Alpha
     License :: OSI Approved :: MIT License


### PR DESCRIPTION
`collections.abc` cannot be parameterized for use in type checking until Python 3.9. See [PEP-585](https://peps.python.org/pep-0585/)