### PR TITLE
Improve info level issues reporting

### DIFF
--- a/mypy_gitlab_code_quality/__init__.py
+++ b/mypy_gitlab_code_quality/__init__.py
@@ -5,6 +5,7 @@ import re
 from base64 import b64encode
 from collections.abc import Hashable, Sequence
 from sys import byteorder, hash_info, stdin
+from typing import TextIO
 
 SEVERITY = {
     "note": "info",
@@ -13,25 +14,73 @@ SEVERITY = {
 
 
 def get_hash(tpl: Sequence[Hashable]) -> str:
-    return b64encode(hash(tpl).to_bytes(hash_info.width // 8, byteorder, signed=True)).decode()
+    return b64encode(
+        hash(tpl).to_bytes(hash_info.width // 8, byteorder, signed=True)
+    ).decode()
 
 
-def parse_line(line: str) -> dict[str, str | dict[str, str | dict[str, int]]] | None:
-    match = re.fullmatch(r"(?P<path>.+?):(?P<line>\d+):(?:\d+:)?\s(?P<error_level>\w+):\s(?P<description>.+)", line)
-    if match is None:
-        return None
-    return {
-        "description": match["description"],
-        "fingerprint": get_hash(match.groups()),
-        "severity": SEVERITY.get(match["error_level"], "unknown"),
-        "location": {
-            "path": match["path"],
-            "lines": {
-                "begin": int(match["line"]),
-            },
-        },
-    }
+def is_info_to_previous_issue(
+    issues: list[dict], severity: str, lineNumber: int
+) -> bool:
+    return (severity == "info") and (
+        issues[-1]["location"]["lines"]["begin"] == lineNumber
+    )
+
+
+def append_line_to_issues(
+    issues: list[dict],
+    fingerprint: str,
+    severity: str,
+    lineNumber: int,
+    description: str,
+    path: str,
+) -> None:
+    if is_info_to_previous_issue(issues, severity, lineNumber):
+        issues[-1]["description"] += f"\n{description}"
+    else:
+        issues.append(
+            {
+                "description": description,
+                "fingerprint": fingerprint,
+                "severity": severity,
+                "location": {
+                    "path": path,
+                    "lines": {
+                        "begin": lineNumber,
+                    },
+                },
+            }
+        )
+
+
+def parse_lines(lines: TextIO) -> list[dict]:
+    issues: list[dict] = []
+    for line in lines:
+        line = line.rstrip("\n")
+        match = re.fullmatch(
+            r"(?P<path>.+?)"
+            r":(?P<line>\d+)"
+            r":(?:\d+:)?\s(?P<error_level>\w+)"
+            r":\s(?P<description>.+)",
+            line,
+        )
+        if match is None:
+            continue
+        fingerprint: str = get_hash(match.groups())
+        severity: str = SEVERITY.get(match["error_level"], "unknown")
+        lineNumber: int = int(match["line"])
+        description: str = match["description"]
+        path: str = match["path"]
+        append_line_to_issues(
+            issues, fingerprint, severity, lineNumber, description, path
+        )
+    return issues
 
 
 def main() -> None:
-    print(json.dumps(list(filter(None, (parse_line(line.rstrip("\n")) for line in stdin))), indent="\t"))
+    print(
+        json.dumps(
+            parse_lines(stdin),
+            indent="\t",
+        )
+    )

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,7 +7,7 @@ description = Simple script to generate gitlab code quality report from output o
 long_description = file: README.md
 long_description_content_type = text/markdown
 url = https://github.com/soul-catcher/mypy-gitlab-code-quality
-version = 0.0.13
+version = 0.0.14
 classifiers =
     Development Status :: 3 - Alpha
     License :: OSI Approved :: MIT License


### PR DESCRIPTION
I noticed that info level issues are incorrectly split, and in fact if they refer to the same line as major level issue, then those are not even separate issues, just hints on how to correct issue.

With that in mind i modified script to append issue info levels to major ones if they refer to the same line (which happens most of the time). Testing it on different repositories proved it to work correctly and reduce bloat of issues (especially multiline).