### PR TITLE
Support for STDIN reprint to STDERR.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Example gitlab codequality report from [gitlab documentation](https://docs.gitla
 # Usage
 `$ mypy program.py | PYTHONHASHSEED=0 mypy-gitlab-code-quality`
 
-This command send to `STDOUT` generated json that can be used as Code Quality report artifact.
+This command send to `STDOUT` generated json that can be used as Code Quality report artifact. When `--re-print` argument is used, script will print its input to `STDERR` which is useful if the `STDIN` needs to be preserved.
 
 **Note: Set environment variable `PYTHONHASHSEED` to `0` to prevent randomize hashes.**
 Constant hashes allow gitlab to determine diff between branches on merge request.

--- a/mypy_gitlab_code_quality/__init__.py
+++ b/mypy_gitlab_code_quality/__init__.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import re
+import sys
 from base64 import b64encode
 from collections.abc import Hashable, Sequence
 from sys import byteorder, hash_info, stdin
@@ -53,10 +54,11 @@ def append_line_to_issues(
         )
 
 
-def parse_lines(lines: TextIO) -> list[dict]:
+def parse_lines(lines: TextIO, re_print: bool) -> list[dict]:
     issues: list[dict] = []
     for line in lines:
         line = line.rstrip("\n")
+        re_print and print(line, file=sys.stderr)
         match = re.fullmatch(
             r"(?P<path>.+?)"
             r":(?P<line>\d+)"
@@ -80,7 +82,7 @@ def parse_lines(lines: TextIO) -> list[dict]:
 def main() -> None:
     print(
         json.dumps(
-            parse_lines(stdin),
+            parse_lines(stdin, "--re-print" in sys.argv[1:]),
             indent="\t",
         )
     )


### PR DESCRIPTION
STDERR is only used to preserve the current interface, but if you prefer I can image to add a few more parameters. Maybe we can have an parameter `-o` for file output and specify which output should be used for re-print.

The re-print is useful for me since I can preserve the MyPy output. 